### PR TITLE
Insert a comment in the entity and text sections

### DIFF
--- a/helpers/editions.xsl
+++ b/helpers/editions.xsl
@@ -342,7 +342,7 @@
     <xsl:template match="/">
         <div class="tei">
             <div class="tei-entities">
-                <xsl:attribute name="class">tei-entities</xsl:attribute>
+                <xsl:comment>TEI Entities</xsl:comment>
                 <xsl:for-each select="/tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:listPlace/tei:place">
                     <xsl:call-template name="place-entity"/>
                 </xsl:for-each>
@@ -361,7 +361,7 @@
             </div>
 
             <div class="tei-text" dir="auto">
-                <xsl:attribute name="class">tei-text</xsl:attribute>
+                <xsl:comment>TEI Text</xsl:comment>
                 <xsl:apply-templates select="tei:TEI/tei:text/tei:body/*"/>
             </div>
         </div>


### PR DESCRIPTION
This prevents the processor generating a self-closing tag if there is no content, which produces invalid HTML5.