### PR TITLE
Explicitly set text direction to rtl for certain languages.

### DIFF
--- a/helpers/TeiEditionsFunctions.php
+++ b/helpers/TeiEditionsFunctions.php
@@ -140,13 +140,14 @@ function full_path_to($file)
     return (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]" . web_path_to($file);
 }
 
-function tei_editions_tei_to_html($path, $img_map)
+function tei_editions_tei_to_html($path, $img_map, $text_lang = null)
 {
 
     $html_lang = function_exists("get_html_lang")
         ? get_html_lang()
         : "en-GB";
     $lang = explode('-', $html_lang)[0];
+    $text_lang = $text_lang === null ? $lang : $text_lang;
     $tohtml = dirname(__FILE__) . '/editions.xsl';
 
     $xsldoc = new DOMDocument();
@@ -162,6 +163,7 @@ function tei_editions_tei_to_html($path, $img_map)
 
     $proc = new XSLTProcessor;
     $proc->setParameter('', "lang", $lang);
+    $proc->setParameter('', 'text-lang', $text_lang);
     $proc->importStylesheet($xsldoc);
     return $proc->transformToXml($xmldoc);
 }

--- a/helpers/TeiEditionsViewHelpers.php
+++ b/helpers/TeiEditionsViewHelpers.php
@@ -253,7 +253,7 @@ function tei_editions_render_document_texts($item) {
 
         if (tei_editions_is_xml_file($path)) {
             $lang = tei_editions_get_language($file->original_filename, $file->original_filename);
-            $text_html[$lang] = tei_editions_tei_to_html($path, $file_url_map);
+            $text_html[$lang] = tei_editions_tei_to_html($path, $file_url_map, strtolower($lang));
         }
     }
 

--- a/helpers/editions.xsl
+++ b/helpers/editions.xsl
@@ -2,6 +2,7 @@
     <xsl:output indent="yes" omit-xml-declaration="yes" encoding="utf-8" method="xml" xalan:indent-amount="4"/>
 
     <xsl:param name="lang" select="'en'"/>
+    <xsl:param name="text-lang" select="'en'"/>
 
     <ehri:strings>
         <search xml:lang="en">Search in this edition</search>
@@ -27,6 +28,21 @@
     </ehri:strings>
 
     <xsl:variable name="messages" select="document('')/*/ehri:strings"/>
+
+    <func:function name="ehri:text-dir">
+        <xsl:param name="text-lang"/>
+
+        <func:result>
+            <xsl:choose>
+                <xsl:when test="$text-lang = 'ar' or $text-lang = 'he' or $text-lang = 'ur' or $text-lang = 'yi'">
+                    <xsl:value-of select="'rtl'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="'auto'"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </func:result>
+    </func:function>
 
     <func:function name="ehri:url-label">
         <xsl:param name="url"/>
@@ -360,7 +376,10 @@
                 </xsl:for-each>
             </div>
 
-            <div class="tei-text" dir="auto">
+            <div class="tei-text">
+                <xsl:attribute name="dir">
+                    <xsl:value-of select="ehri:text-dir($text-lang)"/>
+                </xsl:attribute>
                 <xsl:comment>TEI Text</xsl:comment>
                 <xsl:apply-templates select="tei:TEI/tei:text/tei:body/*"/>
             </div>


### PR DESCRIPTION
This is a bit sketchy since the text lang must be provides as a parameter, which we currently get via the filename alone. However since the fallback is still 'auto' hopefully it will work most of the time.